### PR TITLE
Add support for role_arn

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,8 @@ inputs:
     required: false
   destroy_target:
     required: false
+  role_arn:
+    required: false
 
 runs:
   using: 'node12'

--- a/dist/index.js
+++ b/dist/index.js
@@ -1665,10 +1665,13 @@ function execTerraform() {
         const apply = core.getInput('apply');
         const destroy = core.getInput('destroy');
         const varFile = core.getInput('var_file');
+        const roleArn = core.getInput('role_arn');
         const destroyTarget = core.getInput('destroy_target');
         const backendConfig = core.getInput('backend_config');
         // Optional TF params
         const varFileParam = varFile ? `-var-file=${varFile}` : '';
+        const roleArnTfvarParam = roleArn ? `-var "role_arn=${roleArn}"` : '';
+        const roleArnConfigParam = roleArn ? `-backend-config="role_arn=${roleArn}"` : '';
         const destroyTargetParam = destroyTarget ? `-target=${destroyTarget}` : '';
         const backendConfigParam = backendConfig ? `-backend-config=${backendConfig}` : '';
         // TF format
@@ -1676,7 +1679,7 @@ function execTerraform() {
             throw new Error(`unable to format terraform`);
         }
         // TF init
-        if (shell.exec(`terraform init ${backendConfigParam}`).code) {
+        if (shell.exec(`terraform init ${backendConfigParam} ${roleArnConfigParam}`).code) {
             throw new Error(`unable to initilize terraform`);
         }
         // TF validation
@@ -1696,7 +1699,7 @@ function execTerraform() {
         }
         // TF plan
         if (plan || apply) {
-            if (shell.exec(`terraform plan ${varFileParam} -out=tfplan.out`).code) {
+            if (shell.exec(`terraform plan ${varFileParam} ${roleArnTfvarParam} -out=tfplan.out`).code) {
                 throw new Error(`unable to plan terraform`);
             }
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,11 +42,14 @@ async function execTerraform() {
     const apply = core.getInput('apply')
     const destroy = core.getInput('destroy')
     const varFile = core.getInput('var_file')
+    const roleArn = core.getInput('role_arn')
     const destroyTarget = core.getInput('destroy_target')
     const backendConfig = core.getInput('backend_config')
 
     // Optional TF params
     const varFileParam = varFile ? `-var-file=${varFile}` : ''
+    const roleArnTfvarParam = roleArn ? `-var "role_arn=${roleArn}"` : ''
+    const roleArnConfigParam = roleArn ? `-backend-config="role_arn=${roleArn}"` : ''
     const destroyTargetParam = destroyTarget ? `-target=${destroyTarget}` : ''
     const backendConfigParam = backendConfig ? `-backend-config=${backendConfig}` : ''
 
@@ -56,7 +59,7 @@ async function execTerraform() {
     }
 
     // TF init
-    if (shell.exec(`terraform init ${backendConfigParam}`).code) {
+    if (shell.exec(`terraform init ${backendConfigParam} ${roleArnConfigParam}`).code) {
         throw new Error(`unable to initilize terraform`)
     }
 
@@ -80,7 +83,7 @@ async function execTerraform() {
 
     // TF plan
     if (plan || apply) {
-        if (shell.exec(`terraform plan ${varFileParam} -out=tfplan.out`).code) {
+        if (shell.exec(`terraform plan ${varFileParam} ${roleArnTfvarParam} -out=tfplan.out`).code) {
             throw new Error(`unable to plan terraform`)
         }
     }


### PR DESCRIPTION
## Description
This means we don't have to allways comment out `[assume_]role_arn` when running terraform locally.
However the relevant per-env role ARNs could be supplied per environment in the GHA workflows 

```sh
bucket         = "317566953396-tfstate"
key            = "platform/mesh-eks-gloo/dev/eu-central-1"
region         = "eu-central-1"
dynamodb_table = "317566953396-tfstate-lock"
#role_arn       = "arn:aws:iam::317566953396:role/automation-drone" <-- NO MORE COMMENTING OUT!
```